### PR TITLE
Fix: align icons in center

### DIFF
--- a/assets/sss4givewp-frontend.css
+++ b/assets/sss4givewp-frontend.css
@@ -11,7 +11,7 @@
     width: 40px;
     height: 40px;
     line-height: 0;
-    display: inline-block;
+    display: inline-flex;
     margin: 8px;
     border-radius: 50%;
     font-size: 1.5rem;
@@ -20,6 +20,8 @@
     transition: opacity 0.15s linear;
     text-decoration: none;
     padding: 10px;
+    justify-content: center;
+    align-items: center;
 }
 
 #sss4givewp a svg {


### PR DESCRIPTION
Resolves https://github.com/impress-org/give-simple-social-shout/issues/19

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I updated the style to center align SVG icon.

![Donation Confirmation GiveWP Playground 2022-02-24 at 5 59 19 PM](https://user-images.githubusercontent.com/1784821/155524261-702286d8-5b91-4fff-af0b-2d8a1442e126.jpg)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Review icons on receipt page with legacy form template

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

